### PR TITLE
`Raspberry Pi Image Builder`

### DIFF
--- a/lib/dialog/config
+++ b/lib/dialog/config
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-BUILDER="5.8"
+BUILDER="6.0"
 GCC=`ls -ls /usr/bin/gcc | sed 's/.*\(..\)/\1/' | sed 's/ //g'`
 ARCH=`uname -m`
+MYNAME=`echo $USER | sed -e "s/\b\(.\)/\u\1/g"`
 
-NAME=""
-USERNAME=""
-PASSWORD=""
+NAME="$MYNAME"
+USERNAME="$USER"
+PASSWORD="board"
 CCACHE="0"
 NETWORKMANAGER="1"
 RTW88="0"
@@ -99,8 +100,8 @@ echo 'ENABLE_COMMIT="0"' >> tmp0
 echo 'COMMIT=""' >> tmp0
 echo CORES=\`nproc\` >> tmp0
 echo 'CFLAGS=""' >> tmp0
-echo 'KBUSER="$USER"' >> tmp0
-echo 'KBHOST="raspberrypi"' >> tmp0
+echo 'KBUSER="playboy"' >> tmp0
+echo 'KBHOST="penguin"' >> tmp0
 echo "set_locales(){" >> tmp0
 echo "apt install -y locales" >> tmp0
 echo "export LANGUAGE=${LOCALE}" >> tmp0
@@ -150,8 +151,8 @@ sed -i '52i### DO NOT EDIT BELOW THIS LINE' userdata.txt
 
 # customize your image
 custom_txt (){
-echo "# Default Image Size: 3072MB" > custom.txt
-echo 'IMGSIZE="3072MB"' >> custom.txt
+echo "# Image Size: 3072MB 3584MB 4096MB" > custom.txt
+echo 'IMGSIZE="4096MB"' >> custom.txt
 echo "" >> custom.txt
 echo "# Root Filesystem Types: ext4 btrfs xfs" >> custom.txt
 echo 'FSTYPE="ext4"' >> custom.txt

--- a/lib/dialog/general
+++ b/lib/dialog/general
@@ -6,19 +6,22 @@ source custom.txt
 MAKE_OUTPUT="output/$1"
 BTITLE=`echo $FAMILY: $MOTD: $BOARD: $ARCH_EXT | sed 's/bcm2711v7/bcm2711/g' | sed -e 's/\(.*\)/\U\1/'`
 if [[ "$BOARD" == "bcm2708" ]]; then
-	TITLE=`echo $MOTD $BOARD | sed 's/bcm2708/0\/1\/W/g'`;
+	TITLE=`echo $MOTD $BOARD | sed 's/bcm2708/Zero\/W\/1/g'`;
 fi
 if [[ "$BOARD" == "bcm2709" ]]; then
-	TITLE=`echo $MOTD $BOARD | sed 's/bcm2709/2\/Zero2W\/3/g'`;
+	TITLE=`echo $MOTD $BOARD | sed 's/bcm2709/Zero\/W\/2\/3/g'`;
 fi
 if [[ "$BOARD" == "bcm2710" ]]; then
-	TITLE=`echo $MOTD $BOARD | sed 's/bcm2710/2\/Zero2W\/3/g'`;
+	TITLE=`echo $MOTD $BOARD | sed 's/bcm2710/Zero\/W\/2\/3/g'`;
 fi
 if [[ "$BOARD" == "bcm2711" ]]; then
 	TITLE=`echo $MOTD $BOARD | sed 's/bcm2711/4\/400/g'`;
 fi
 if [[ "$BOARD" == "bcm2711v7" ]]; then
 	TITLE=`echo $MOTD $BOARD | sed 's/bcm2711v7/4\/400/g'`;
+fi
+if [[ "$BOARD" == "bcm2712" ]]; then
+	TITLE=`echo $MOTD $BOARD | sed 's/bcm2712/5/g'`;
 fi
 DIALOG_CANCEL=1
 DIALOG_ESC=255

--- a/lib/function/patching
+++ b/lib/function/patching
@@ -11,7 +11,7 @@ echo -en "Firmware"
 echo -en " ${PNK}[${FIN}${WHT}downloading${FIN}${PNK}]${FIN}"
 aria2c -q ${BINURL}LICENCE.broadcom
 aria2c -q ${BINURL}COPYING.linux
-if [[ "$BOARD_EXT" == "rpi-4" || "$BOARD_EXT" == "rpi-5" ]]; then
+if [[ "$ARCH_EXT" == "armhf" || "$ARCH_EXT" == "arm64" ]]; then
 	aria2c -q ${BINURL}fixup4.dat
 	aria2c -q ${BINURL}fixup4cd.dat
 	aria2c -q ${BINURL}fixup4db.dat
@@ -20,14 +20,6 @@ if [[ "$BOARD_EXT" == "rpi-4" || "$BOARD_EXT" == "rpi-5" ]]; then
 	aria2c -q ${BINURL}start4cd.elf
 	aria2c -q ${BINURL}start4db.elf
 	aria2c -q ${BINURL}start4x.elf
-	cd ..
-	if [[ `ls firmware/{fixup4.dat,fixup4cd.dat,fixup4db.dat,fixup4x.dat,start4.elf,start4cd.elf,start4db.elf,start4x.elf,LICENCE.broadcom,COPYING.linux}` ]] > /dev/null 2>&1; then
-		echo -e " ${PNK}[${FIN}${GRN}done${FIN}${PNK}]${FIN}"
-	else
-		echo -en " ${YLW}[${FIN}${RED}failed${FIN}${YLW}]${FIN}"; echo ""
-		exit 0
-	fi
-else
 	aria2c -q ${BINURL}bootcode.bin
 	aria2c -q ${BINURL}fixup.dat
 	aria2c -q ${BINURL}fixup_cd.dat
@@ -38,7 +30,32 @@ else
 	aria2c -q ${BINURL}start_db.elf
 	aria2c -q ${BINURL}start_x.elf
 	cd ..
-	if [[ `ls firmware/{bootcode.bin,fixup.dat,fixup_cd.dat,fixup_db.dat,fixup_x.dat,start.elf,start_cd.elf,start_db.elf,start_x.elf,LICENCE.broadcom,COPYING.linux}` ]] > /dev/null 2>&1; then
+	echo -en " ${PNK}[${FIN}${WHT}checking${FIN}${PNK}]${FIN}"
+	if [[ `ls firmware/{fixup4.dat,fixup4cd.dat,fixup4db.dat,fixup4x.dat,start4.elf,start4cd.elf,start4db.elf,start4x.elf}` ]] > /dev/null 2>&1; then
+		:;
+	else
+		echo -en " ${YLW}[${FIN}${RED}failed${FIN}${YLW}]${FIN}"; echo ""
+		exit 0
+	fi
+	if [[ `ls firmware/{bootcode.bin,fixup.dat,fixup_cd.dat,fixup_db.dat,fixup_x.dat,start.elf,start_cd.elf,start_db.elf,start_x.elf}` ]] > /dev/null 2>&1; then
+		echo -e " ${PNK}[${FIN}${GRN}done${FIN}${PNK}]${FIN}"
+	else
+		echo -en " ${YLW}[${FIN}${RED}failed${FIN}${YLW}]${FIN}"; echo ""
+		exit 0
+	fi
+fi
+if [[ "$ARCH_EXT" == "armel" ]]; then
+	aria2c -q ${BINURL}bootcode.bin
+	aria2c -q ${BINURL}fixup.dat
+	aria2c -q ${BINURL}fixup_cd.dat
+	aria2c -q ${BINURL}fixup_db.dat
+	aria2c -q ${BINURL}fixup_x.dat
+	aria2c -q ${BINURL}start.elf
+	aria2c -q ${BINURL}start_cd.elf
+	aria2c -q ${BINURL}start_db.elf
+	aria2c -q ${BINURL}start_x.elf
+	cd ..
+	if [[ `ls firmware/{bootcode.bin,fixup.dat,fixup_cd.dat,fixup_db.dat,fixup_x.dat,start.elf,start_cd.elf,start_db.elf,start_x.elf}` ]] > /dev/null 2>&1; then
 		echo -e " ${PNK}[${FIN}${GRN}done${FIN}${PNK}]${FIN}"
 	else
 		echo -en " ${YLW}[${FIN}${RED}failed${FIN}${YLW}]${FIN}"; echo ""
@@ -165,6 +182,7 @@ rm -f scripts/package/{builddeb,mkdebian}
 cp -fr ../../packaging/{builddeb,mkdebian} scripts/package/
 chmod +x scripts/package/{builddeb,mkdebian}
 cp -f ../../packaging/headers-byteshift.patch headers-byteshift.patch
+cp -f ../../packaging/dtclist.txt dtclist.txt
 linux_patches
 user_patches
 linux_packaging

--- a/lib/function/staging
+++ b/lib/function/staging
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-partitions(){
+partitions (){
 if [[ "$OFFSET" == "8192" ]]; then IMG_OFFSET="4MiB"; fi
 truncate -s ${IMGSIZE} "${IMAGE_FOLDER}${IMAGE_FILE_NAME}"
 parted --script "${IMAGE_FOLDER}${IMAGE_FILE_NAME}" \
@@ -27,7 +27,7 @@ umount p2
 $MOUNT_ROOTFS
 }
 
-filesystem(){
+filesystem (){
 MAKE_BOOTFS="mkfs -t vfat -n BOOT ${IMAGE_LOOP_DEV_BOOT}"
 BOOT_PATH="/boot/broadcom"
 if [[ "$FSTYPE" == "ext4" ]]; then
@@ -50,7 +50,7 @@ if [[ "$FSTYPE" == "xfs" ]]; then
 fi
 }
 
-create_fstab(){
+create_fstab (){
 tee p2/etc/fstab <<EOF
 UUID=${BOOT_UUID}	${BOOT_PATH}	vfat	defaults,flush 0 2
 UUID=${ROOT_UUID}	/	${ROOTFS_TABLE}
@@ -58,7 +58,7 @@ tmpfs	/tmp		tmpfs	defaults,nosuid 0 0
 EOF
 }
 
-partition_uuid(){
+partition_uuid (){
 BOOT_UUID=$(blkid -o export -- "${IMAGE_LOOP_DEV_BOOT}" | sed -ne 's/^UUID=//p')
 ROOT_UUID=$(blkid -o export -- "${IMAGE_LOOP_DEV_ROOTFS}" | sed -ne 's/^UUID=//p')
 ROOT_PARTUUID=$(blkid -o export -- "${IMAGE_LOOP_DEV_ROOTFS}" | sed -ne 's/^PARTUUID=//p')
@@ -68,13 +68,13 @@ echo ROOT_PARTUUID='"'$ROOT_PARTUUID'"' >> part-uuid.txt
 source part-uuid.txt
 }
 
-cmdline(){
+cmdline (){
 tee p1/cmdline.txt <<EOF
 ${CONSOLE} root=PARTUUID=${ROOT_PARTUUID} ${ROOTFSTYPE} fsck.repair=yes ${EXTRA} rootwait
 EOF
 }
 
-bcm2711_config(){
+config_dot_txt (){
 tee p1/config.txt <<EOF
 arm_64bit=1
 initramfs initrd.gz followkernel
@@ -129,6 +129,7 @@ disable_overscan=1
 # uncomment to overclock: https://www.tomshardware.com/how-to/overclock-any-raspberry-pi
 #arm_freq=
 #gpu_freq=
+#core_freq=
 #over_voltage=
 #force_turbo=1
 
@@ -152,6 +153,8 @@ enable_uart=0
 # disable wifi and bluetooth
 #dtoverlay=disable-wifi
 #dtoverlay=disable-bt
+#dtoverlay=pi3-disable-wifi
+#dtoverlay=pi3-disable-bt
 
 # remove test rainbow
 disable_splash=1
@@ -171,261 +174,5 @@ dtoverlay=vc4-kms-v3d
 #dtoverlay=vc4-fkms-v3d
 max_framebuffers=2
 arm_boost=1
-EOF
-}
-
-bcm2710_config(){
-tee p1/config.txt <<EOF
-arm_64bit=1
-initramfs initrd.gz followkernel
-
-# uncomment if you get no picture on HDMI for a default "safe" mode
-#hdmi_safe=1
-
-# uncomment this if your display has a black border of unused pixels visible
-# and your display can output without overscan
-disable_overscan=1
-
-# uncomment the following to adjust overscan. Use positive numbers if console
-# goes off screen, and negative if there is too much border
-#overscan_left=16
-#overscan_right=16
-#overscan_top=16
-#overscan_bottom=16
-
-# uncomment to force a console size. By default it will be display's size minus
-# overscan.
-#framebuffer_width=1280
-#framebuffer_height=720
-
-# uncomment if hdmi display is not detected and composite is being output
-#hdmi_force_hotplug=1
-
-# uncomment to force a specific HDMI mode (this will force VGA)
-#hdmi_group=1
-#hdmi_mode=1
-
-# uncomment to force a HDMI mode rather than DVI. This can make audio work in
-# DMT (computer monitor) modes
-#hdmi_drive=2
-
-# uncomment to increase signal to HDMI, if you have interference, blanking, or
-# no display
-#config_hdmi_boost=4
-
-# uncomment for composite PAL
-#sdtv_mode=2
-
-# camera
-#start_x=1
-#gpu_mem=128
-
-# automatically load overlays for detected cameras
-#camera_auto_detect=1
-
-# automatically load overlays for detected DSI displays
-#display_auto_detect=1
-
-# uncomment to overclock: https://www.tomshardware.com/how-to/overclock-any-raspberry-pi
-#arm_freq=
-#core_freq=
-#over_voltage=
-
-# uncomment some or all of these to enable the optional hardware interfaces
-#dtparam=i2c_arm=on
-#dtparam=i2s=on
-#dtparam=spi=on
-
-# uncomment this to enable infrared communication.
-#dtoverlay=gpio-ir,gpio_pin=17
-#dtoverlay=gpio-ir-tx,gpio_pin=18
-
-# additional overlays and parameters are documented /boot/overlays/README
-
-# enable audio (loads snd_bcm2835)
-dtparam=audio=on
-
-# enable uart
-enable_uart=0
-
-# disable wifi and bluetooth
-#dtoverlay=pi3-disable-wifi
-#dtoverlay=pi3-disable-bt
-
-# remove test rainbow
-disable_splash=1
-
-# disables the warning overlays
-#avoid_warnings=1
-EOF
-}
-
-bcm2709_config(){
-tee p1/config.txt <<EOF
-initramfs initrd.gz followkernel
-
-# uncomment if you get no picture on HDMI for a default "safe" mode
-#hdmi_safe=1
-
-# uncomment this if your display has a black border of unused pixels visible
-# and your display can output without overscan
-disable_overscan=1
-
-# uncomment the following to adjust overscan. Use positive numbers if console
-# goes off screen, and negative if there is too much border
-#overscan_left=16
-#overscan_right=16
-#overscan_top=16
-#overscan_bottom=16
-
-# uncomment to force a console size. By default it will be display's size minus
-# overscan.
-#framebuffer_width=1280
-#framebuffer_height=720
-
-# uncomment if hdmi display is not detected and composite is being output
-#hdmi_force_hotplug=1
-
-# uncomment to force a specific HDMI mode (this will force VGA)
-#hdmi_group=1
-#hdmi_mode=1
-
-# uncomment to force a HDMI mode rather than DVI. This can make audio work in
-# DMT (computer monitor) modes
-#hdmi_drive=2
-
-# uncomment to increase signal to HDMI, if you have interference, blanking, or
-# no display
-#config_hdmi_boost=4
-
-# uncomment for composite PAL
-#sdtv_mode=2
-
-# camera
-#start_x=1
-#gpu_mem=128
-
-# automatically load overlays for detected cameras
-#camera_auto_detect=1
-
-# automatically load overlays for detected DSI displays
-#display_auto_detect=1
-
-# uncomment to overclock: https://www.tomshardware.com/how-to/overclock-any-raspberry-pi
-#arm_freq=
-#core_freq=
-#over_voltage=
-
-# uncomment some or all of these to enable the optional hardware interfaces
-#dtparam=i2c_arm=on
-#dtparam=i2s=on
-#dtparam=spi=on
-
-# uncomment this to enable infrared communication.
-#dtoverlay=gpio-ir,gpio_pin=17
-#dtoverlay=gpio-ir-tx,gpio_pin=18
-
-# additional overlays and parameters are documented /boot/overlays/README
-
-# enable audio (loads snd_bcm2835)
-dtparam=audio=on
-
-# enable uart
-enable_uart=0
-
-# disable wifi and bluetooth
-#dtoverlay=pi3-disable-wifi
-#dtoverlay=pi3-disable-bt
-
-# remove test rainbow
-disable_splash=1
-
-# disables the warning overlays
-#avoid_warnings=1
-EOF
-}
-
-bcm2708_config(){
-tee p1/config.txt <<EOF
-initramfs initrd.gz followkernel
-
-# uncomment if you get no picture on HDMI for a default "safe" mode
-#hdmi_safe=1
-
-# uncomment this if your display has a black border of unused pixels visible
-# and your display can output without overscan
-disable_overscan=1
-
-# uncomment the following to adjust overscan. Use positive numbers if console
-# goes off screen, and negative if there is too much border
-#overscan_left=16
-#overscan_right=16
-#overscan_top=16
-#overscan_bottom=16
-
-# uncomment to force a console size. By default it will be display's size minus
-# overscan.
-#framebuffer_width=1280
-#framebuffer_height=720
-
-# uncomment if hdmi display is not detected and composite is being output
-#hdmi_force_hotplug=1
-
-# uncomment to force a specific HDMI mode (this will force VGA)
-#hdmi_group=1
-#hdmi_mode=1
-
-# uncomment to force a HDMI mode rather than DVI. This can make audio work in
-# DMT (computer monitor) modes
-#hdmi_drive=2
-
-# uncomment to increase signal to HDMI, if you have interference, blanking, or
-# no display
-#config_hdmi_boost=4
-
-# uncomment for composite PAL
-#sdtv_mode=2
-
-# camera
-#start_x=1
-#gpu_mem=128
-
-# automatically load overlays for detected cameras
-#camera_auto_detect=1
-
-# automatically load overlays for detected DSI displays
-#display_auto_detect=1
-
-# uncomment to overclock: https://www.tomshardware.com/how-to/overclock-any-raspberry-pi
-#arm_freq=
-#core_freq=
-#over_voltage=
-
-# uncomment some or all of these to enable the optional hardware interfaces
-#dtparam=i2c_arm=on
-#dtparam=i2s=on
-#dtparam=spi=on
-
-# uncomment this to enable infrared communication.
-#dtoverlay=gpio-ir,gpio_pin=17
-#dtoverlay=gpio-ir-tx,gpio_pin=18
-
-# additional overlays and parameters are documented /boot/overlays/README
-
-# enable audio (loads snd_bcm2835)
-dtparam=audio=on
-
-# enable uart
-enable_uart=0
-
-# disable wifi and bluetooth
-#dtoverlay=disable-wifi
-#dtoverlay=disable-bt
-
-# remove test rainbow
-disable_splash=1
-
-# disables the warning overlays
-#avoid_warnings=1
 EOF
 }

--- a/lib/source
+++ b/lib/source
@@ -26,7 +26,7 @@ else
 		fi
 	done
 fi
-if [[ "$BUILDER" == "5.8" ]]; then
+if [[ "$BUILDER" == "6.0" ]]; then
 	:;
 else
 	echo -e "The ${WHT}$UD${FIN} file has expired. Please create a new one."

--- a/packaging/builddeb
+++ b/packaging/builddeb
@@ -50,10 +50,9 @@ libc_headers_dir="$objtree/debian/headertmp"
 dbg_dir="$objtree/debian/dbgtmp"
 libc_headers_packagename=linux-libc-dev
 dbg_packagename=$packagename-dbg
-# set by pkgvars
 packagename=$linux_packagename
 kernel_headers_packagename=$headers_packagename
-# end of pkgvars
+
 if [ "$ARCH" = "um" ] ; then
 	packagename=user-mode-linux-$version
 fi
@@ -93,12 +92,15 @@ else
 	if [ -f arch/arm/boot/zImage ]; then
 		mkdir -p "$tmpdir/$boot_path"
 		cp arch/arm/boot/zImage "$tmpdir/boot/Image"
-		cp arch/arm/boot/zImage "$tmpdir/$boot_path/$kernel_img"
+		cp arch/arm/boot/zImage "$tmpdir/$boot_path/kernel.img"
+		cp arch/arm/boot/zImage "$tmpdir/$boot_path/kernel7.img"
+		cp arch/arm/boot/zImage "$tmpdir/$boot_path/kernel7l.img"
 	fi
 	if [ -f arch/arm64/boot/Image ]; then
 		mkdir -p "$tmpdir/$boot_path"
 		cp arch/arm64/boot/Image "$tmpdir/boot/Image"
-		cp arch/arm64/boot/Image "$tmpdir/$boot_path/$kernel_img"
+		cp arch/arm64/boot/Image "$tmpdir/$boot_path/kernel8.img"
+		cp arch/arm64/boot/Image "$tmpdir/$boot_path/kernel_2712.img"
 	fi
 	if [ -f firmware/bootcode.bin ]; then
 		install -m 0644 firmware/bootcode.bin "$tmpdir/$boot_path"
@@ -168,126 +170,30 @@ if [ "$ARCH" != "um" ]; then
 	mv $libc_headers_dir/usr/include/asm $libc_headers_dir/usr/include/$host_arch/
 fi
 
-# Install dtbs
-if [ -d $tmpdir/$boot_path ]; then :; else mkdir -p "$tmpdir/$boot_path"; fi
-if [ "$board_series" = "rpi-4" ] || [ "$board_series" = "rpi-5" ]; then
-	# path 1
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2711-rpi-4-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2711-rpi-4-b.dtb" "$tmpdir/$boot_path/bcm2711-rpi-4-b.dtb"
+# Update dtb list
+for dtclist in `cat dtclist.txt`; do ls $tmpdir/$linux_path/$dtclist 2>/dev/null | tee -a dtclist.new > /dev/null 2>&1; done
+rm -f "dtclist.txt"; mv -f "dtclist.new" "dtclist.txt"
+
+# Installing dtb files
+if [ -d $tmpdir/$linux_path ]; then
+	mkdir -p "$tmpdir/$boot_path"
+	for dtclist in `cat dtclist.txt`; do cp -r "$dtclist" 2>/dev/null "$tmpdir/$boot_path"; done
+	rm -f dtclist.txt
+	# install overlays
+	if ls "$tmpdir/$linux_path/*.dtbo" > /dev/null 2>&1; then
+		mkdir -p "$tmpdir/$linux_path/overlays"
+		cp -r "$tmpdir/$linux_path/*.dtbo" "$tmpdir/$linux_path/overlays/"
+		rm -f "$tmpdir/$linux_path/*.dtbo"
 	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2711-rpi-400.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2711-rpi-400.dtb" "$tmpdir/$boot_path/bcm2711-rpi-400.dtb"
+	if [ -d "$tmpdir/$overlays_path" ]; then
+		mkdir -p "$tmpdir/$boot_path/overlays"
+		cp -r "$tmpdir/$overlays_path/" "$tmpdir/$boot_path"
+	else
+		if [ -d "$tmpdir/$linux_path/overlays" ]; then
+			mkdir -p "$tmpdir/$boot_path/overlays"
+			cp -r "$tmpdir/$linux_path/overlays" "$tmpdir/$boot_path"
+		fi
 	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2711-rpi-cm4.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2711-rpi-cm4.dtb" "$tmpdir/$boot_path/bcm2711-rpi-cm4.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2711-rpi-cm4s.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2711-rpi-cm4s.dtb" "$tmpdir/$boot_path/bcm2711-rpi-cm4s.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2712-rpi-5-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2712-rpi-5-b.dtb" "$tmpdir/$boot_path/bcm2712-rpi-5-b.dtb"
-	fi
-	# path 2
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2711-rpi-4-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2711-rpi-4-b.dtb" "$tmpdir/$boot_path/bcm2711-rpi-4-b.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2711-rpi-400.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2711-rpi-400.dtb" "$tmpdir/$boot_path/bcm2711-rpi-400.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2711-rpi-cm4.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2711-rpi-cm4.dtb" "$tmpdir/$boot_path/bcm2711-rpi-cm4.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2711-rpi-cm4s.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2711-rpi-cm4s.dtb" "$tmpdir/$boot_path/bcm2711-rpi-cm4s.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2712-rpi-5-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2712-rpi-5-b.dtb" "$tmpdir/$boot_path/bcm2712-rpi-5-b.dtb"
-	fi
-fi
-if [ "$board_series" = "rpi-3" ] || [ "$board_series" = "rpi-2+3" ]; then
-	# path 1
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2709-rpi-2-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2709-rpi-2-b.dtb" "$tmpdir/$boot_path/bcm2709-rpi-2-b.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-2-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-2-b.dtb" "$tmpdir/$boot_path/bcm2710-rpi-2-b.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-zero-2.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-zero-2.dtb" "$tmpdir/$boot_path/bcm2710-rpi-zero-2.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-zero-2-w.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-zero-2-w.dtb" "$tmpdir/$boot_path/bcm2710-rpi-zero-2-w.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-cm3.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-cm3.dtb" "$tmpdir/$boot_path/bcm2710-rpi-cm3.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-3-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-3-b.dtb" "$tmpdir/$boot_path/bcm2710-rpi-3-b.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-3-b-plus.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2710-rpi-3-b-plus.dtb" "$tmpdir/$boot_path/bcm2710-rpi-3-b-plus.dtb"
-	fi
-	# path 2
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2709-rpi-2-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2709-rpi-2-b.dtb" "$tmpdir/$boot_path/bcm2709-rpi-2-b.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-2-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-2-b.dtb" "$tmpdir/$boot_path/bcm2710-rpi-2-b.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-zero-2.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-zero-2.dtb" "$tmpdir/$boot_path/bcm2710-rpi-zero-2.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-zero-2-w.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-zero-2-w.dtb" "$tmpdir/$boot_path/bcm2710-rpi-zero-2-w.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-cm3.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-cm3.dtb" "$tmpdir/$boot_path/bcm2710-rpi-cm3.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-3-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-3-b.dtb" "$tmpdir/$boot_path/bcm2710-rpi-3-b.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-3-b-plus.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2710-rpi-3-b-plus.dtb" "$tmpdir/$boot_path/bcm2710-rpi-3-b-plus.dtb"
-	fi
-fi
-if [ "$board_series" = "rpi" ]; then
-	# path 1
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2708-rpi-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2708-rpi-b.dtb" "$tmpdir/$boot_path/bcm2708-rpi-b.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2708-rpi-b-plus.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2708-rpi-b-plus.dtb" "$tmpdir/$boot_path/bcm2708-rpi-b-plus.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2708-rpi-b-rev1.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2708-rpi-b-rev1.dtb" "$tmpdir/$boot_path/bcm2708-rpi-b-rev1.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2708-rpi-zero.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2708-rpi-zero.dtb" "$tmpdir/$boot_path/bcm2708-rpi-zero.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/bcm2708-rpi-zero-w.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/bcm2708-rpi-zero-w.dtb" "$tmpdir/$boot_path/bcm2708-rpi-zero-w.dtb"
-	fi
-	# path 2
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2708-rpi-b.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2708-rpi-b.dtb" "$tmpdir/$boot_path/bcm2708-rpi-b.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2708-rpi-b-plus.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2708-rpi-b-plus.dtb" "$tmpdir/$boot_path/bcm2708-rpi-b-plus.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2708-rpi-b-rev1.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2708-rpi-b-rev1.dtb" "$tmpdir/$boot_path/bcm2708-rpi-b-rev1.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2708-rpi-zero.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2708-rpi-zero.dtb" "$tmpdir/$boot_path/bcm2708-rpi-zero.dtb"
-	fi
-	if [ -f $tmpdir/usr/lib/$linux_packagename/broadcom/bcm2708-rpi-zero-w.dtb ]; then
-		cp -r "$tmpdir/usr/lib/$linux_packagename/broadcom/bcm2708-rpi-zero-w.dtb" "$tmpdir/$boot_path/bcm2708-rpi-zero-w.dtb"
-	fi
-fi
-# Install overlays
-if [ -d $tmpdir/usr/lib/$linux_packagename/overlays ]; then
-	mkdir -p "$tmpdir/$boot_path/overlays";
-	cp -r "$tmpdir/usr/lib/$linux_packagename/overlays/" "$tmpdir/$boot_path/"
 fi
 
 # Install the maintainer scripts
@@ -319,8 +225,8 @@ set -e
 if [ -f /boot/Image ]; then
 	rm -fr /boot/{Image,vmlinuz-*,System.map-*,config-*,initrd.img*,initrd.gz};
 fi
-if [ -f /$boot_path/$kernel_img ]; then
-	rm -fr /$boot_path/{Image,$kernel_img,initrd.gz,initrd.img*,System.map-*,config-*,vmlinuz-*,*.dtb,bootcode.bin,fixup*.dat,start*.elf,LICENCE.broadcom,COPYING.linux};
+if [ -d /$boot_path ]; then
+	rm -fr /$boot_path/{Image,*.img,initrd.gz,initrd.img*,System.map-*,config-*,vmlinuz-*,*.dtb,bootcode.bin,fixup*.dat,start*.elf,LICENCE.broadcom,COPYING.linux};
 fi
 if [ -d /$boot_path/overlays ]; then
 	rm -fdr /$boot_path/overlays;

--- a/packaging/dtclist.txt
+++ b/packaging/dtclist.txt
@@ -1,0 +1,17 @@
+bcm2708-rpi-b.dtb
+bcm2708-rpi-b-plus.dtb
+bcm2708-rpi-b-rev1.dtb
+bcm2708-rpi-zero.dtb
+bcm2708-rpi-zero-w.dtb
+bcm2709-rpi-2-b.dtb
+bcm2710-rpi-2-b.dtb
+bcm2710-rpi-zero-2.dtb
+bcm2710-rpi-zero-2-w.dtb
+bcm2710-rpi-cm3.dtb
+bcm2710-rpi-3-b.dtb
+bcm2710-rpi-3-b-plus.dtb
+bcm2711-rpi-4-b.dtb
+bcm2711-rpi-400.dtb
+bcm2711-rpi-cm4.dtb
+bcm2711-rpi-cm4s.dtb
+bcm2712-rpi-5-b.dtb

--- a/packaging/pkgvars
+++ b/packaging/pkgvars
@@ -1,15 +1,27 @@
 #!/bin/bash
 
 COMPRESSION="xz"
+PLATFORM="broadcom"
 LINUX_IMAGE="linux-image-${SERIES}"
 LINUX_HEADERS="linux-headers-${SERIES}"
 
 linux_packaging(){
+# install target
+if [[ "$ARCH" == "arm" ]]; then
+	LINUX_PATH="usr/lib/${LINUX_IMAGE}"
+fi
+if [[ "$ARCH" == "arm64" ]]; then
+	LINUX_PATH="usr/lib/${LINUX_IMAGE}/${PLATFORM}"
+fi
+OVERLAY_PATH="usr/lib/${LINUX_IMAGE}/overlays"
+INSTALL_PATH="boot/${PLATFORM}"
 echo "# packaging variables" > "scripts/package/pkgvars"
-echo board_series='"'$BOARD_EXT'"' >> "scripts/package/pkgvars"
+echo board_series='"'$SERIES'"' >> "scripts/package/pkgvars"
 echo kernel_img='"'$KERNEL_IMG'"' >> "scripts/package/pkgvars"
 echo linux_packagename='"'$LINUX_IMAGE'"' >> "scripts/package/pkgvars"
 echo headers_packagename='"'$LINUX_HEADERS'"' >> "scripts/package/pkgvars"
 echo compression='"'$COMPRESSION'"' >> "scripts/package/pkgvars"
-echo boot_path='"'boot/broadcom'"' >> "scripts/package/pkgvars"
+echo linux_path='"'$LINUX_PATH'"' >> "scripts/package/pkgvars"
+echo overlays_path='"'$OVERLAY_PATH'"' >> "scripts/package/pkgvars"
+echo boot_path='"'$INSTALL_PATH'"' >> "scripts/package/pkgvars"
 }

--- a/scripts/stage1
+++ b/scripts/stage1
@@ -77,7 +77,7 @@ else
 	partition_uuid > /dev/null 2>&1
 fi
 
-# cmd line
+# command line
 cmdline > /dev/null 2>&1
 if [[ -f "p1/cmdline.txt" ]]; then
 	:;
@@ -88,11 +88,7 @@ else
 	exit 0
 fi
 # config dot txt
-if [[ "$BOARD_EXT" == "rpi-4" || "$BOARD_EXT" == "rpi-5" ]]; then
-	bcm2711_config > /dev/null 2>&1
-else
-	${BOARD}_config > /dev/null 2>&1
-fi
+config_dot_txt > /dev/null 2>&1
 if [[ -f "p1/config.txt" ]]; then
 	:;
 else
@@ -102,7 +98,7 @@ else
 	echo_fail
 	exit 0
 fi
-if [[ "$BOARD" == "bcm2711v7" ]]; then
+if [[ "$ARCH" == "arm" ]]; then
 	sed -i '1d' p1/config.txt
 fi
 

--- a/scripts/stage2
+++ b/scripts/stage2
@@ -197,7 +197,7 @@ echo "Moving scripts ..."
 cd ~
 mkdir -p /usr/local/bin
 mkdir -p /usr/local/sbin
-if [[ "$BOARD_EXT" == "rpi-4" || "$BOARD_EXT" == "rpi-5" ]]; then
+if [[ "$BOARD_EXT" == "rpi-3" || "$BOARD_EXT" == "rpi-4" || "$BOARD_EXT" == "rpi-5" ]]; then
 	wget -cq --show-progress ${URL}deb-eeprom
 	mv -f deb-eeprom /usr/local/bin/
 fi
@@ -331,7 +331,7 @@ rm -fdR pi-bluetooth*
 rpi_userland
 
 # eeprom
-if [[ "$BOARD_EXT" == "rpi-4" || "$BOARD_EXT" == "rpi-5" ]]; then
+if [[ "$BOARD_EXT" == "rpi-2+3" || "$BOARD_EXT" == "rpi-3" || "$BOARD_EXT" == "rpi-4" || "$BOARD_EXT" == "rpi-5" ]]; then
 	eeprom_support
 fi
 
@@ -347,10 +347,7 @@ stage2_kernel # universal
 
 # brcm modules
 bcm_modules > /dev/null 2>&1
-if [[ "$BOARD" == "bcm2709" || "$BOARD" == "bcm2710" ]]; then
-	# audio module
-	echo "snd_bcm2835" >> /etc/modules
-fi
+echo "snd_bcm2835" >> /etc/modules
 
 # clean misc files
 rm -f {*.patch,*led*,*eeprom*}


### PR DESCRIPTION
This update mostly pertains to kernel packaging. Some builds will no longer be as isolated as they were in the past. This will make for adding new boards in the future a much quicker process. It will also add backwards compatibility in some cases. For example PI4 (ARM64) images can also be used on PI3s.

builder: 6.0