### PR TITLE
Added ncompile support for Devuan Daedalus.

### DIFF
--- a/scripts/.ncompile
+++ b/scripts/.ncompile
@@ -26,6 +26,10 @@ sudo debconf-apt-progress -- apt install -y \
 	ccache
 }
 
+daedalus-ncompile (){
+	bookworm-ncompile
+}
+
 trixie-ncompile (){
 sudo debconf-apt-progress -- apt install -y \
 	build-essential bison bc git dialog patch dosfstools zip unzip parted \
@@ -74,7 +78,7 @@ if [[ "$HOST_ARCH" == "x86_64" ]]; then
 	exit 0
 fi
 
-if [[ "$HOST_CODENAME" =~ ^(bullseye|bookworm|trixie|jammy|noble)$ ]]; then
+if [[ "$HOST_CODENAME" =~ ^(bullseye|bookworm|daedalus|trixie|jammy|noble)$ ]]; then
 	echo ""
 	${HOST_CODENAME}-ncompile
 else


### PR DESCRIPTION
Bash script "scripts/.ncompile" didn't complain when function "daedalus-ncompile" called function "bookworm-ncompile".